### PR TITLE
enable win32 (clean)

### DIFF
--- a/lib/cmudict.js
+++ b/lib/cmudict.js
@@ -1,4 +1,5 @@
-var fs = require('fs');
+var fs = require('fs'),
+    nodePath = require('path');
 
 function CMUDict() {
   this._cache = null;
@@ -20,8 +21,11 @@ CMUDict.prototype.get = function(lookup, cb) {
     if (path === null) {
       throw 'cmudict.js cannot find its lib directory.';
     }
-    path = path.split('/');
-    path = path.slice(0, path.length-1).join('/') + '/cmu/cmudict.0.7a';
+  
+    //Select appropriate file path slash for Windows v *Nix
+    console.log('path.sep reads as:',nodePath.sep);
+    path = path.split(nodePath.sep);
+    path = path.slice(0, path.length-1).concat('cmu','cmudict.0.7a').join(nodePath.sep);
 
     // Note: this originally used node-mmap but repeated runs showed basically
     // the same performance so I just stuck with readFileSync.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { "name" :            "cmudict"
 , "description" :     "A node.js wrapper around the CMU Pronunciation Dictionary"
 , "keywords" :        ["cmudict", "nlp", "language", "linguistics", "english"]
-, "version" :         "1.0.1"
+, "version" :         "1.0.2"
 , "author" :          "Nathaniel K Smith <nathanielksmith@gmail.com> (http://chiptheglasses.com)"
 , "repository" :    { "type" :  "git"
                     , "url" :   "http://github.com/nathanielksmith/node-cmudict" }
@@ -11,7 +11,8 @@
                     , "darwin"
                     , "freebsd"
                     , "solaris"
-                    , "sunos" ]
+                    , "sunos"
+                    , "win32" ]
 , "config":         { "native" : false }
 , "main":             "./lib/cmudict"
 , "directories" :   { "lib" : "./lib/cmudict" }

--- a/test/get.js
+++ b/test/get.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var CMUDict = require('../cmudict').CMUDict;
+var CMUDict = require('../lib/cmudict').CMUDict;
 
 var c = new CMUDict();
 


### PR DESCRIPTION
- Made slight change to `lib\cmudict.js` to enable parsing/joining of
  win32 file path (if path starts '/', use '/'; otherwise use '\')
- Fixed relative path in `require()` call of `test\get.js`
- Incremented version to `1.0.2` and added `win32` to os arrray in
  `package.json`
